### PR TITLE
Updated copyright for high DPI images

### DIFF
--- a/copyright
+++ b/copyright
@@ -94,12 +94,13 @@ Copyright: Nate Graham <pointedstick@zoho.com>
 License: CC-BY-SA-4.0
 
 Files:
- images/land/sky2@2x.jpg
- images/land/sea3@2x.jpg
- images/land/beach4@2x.jpg
- images/land/canyon9@2x.jpg
+ images/land/sky2*
+ images/land/sea3*
+ images/land/beach4*
+ images/land/canyon9*
 Copyright: Emily Mell <hasmidas@gmail.com>
 License: public domain
+Based on public domain images taken from unsplash.com
 
 Files:
  images/icon/gat*
@@ -272,7 +273,6 @@ Files:
  images/land/beach0*
  images/land/beach2*
  images/land/beach3*
- images/land/beach4*
  images/land/beach5*
  images/land/beach6*
  images/land/canyon0*
@@ -323,12 +323,10 @@ Files:
  images/land/mountain8*
  images/land/mountain9*
  images/land/sea1*
- images/land/sea3*
  images/land/sea5*
  images/land/sea7*
  images/land/sea8*
  images/land/sky0*
- images/land/sky2*
  images/land/sky3*
  images/land/sky4*
  images/land/sky5*

--- a/copyright
+++ b/copyright
@@ -96,6 +96,8 @@ License: CC-BY-SA-4.0
 Files:
  images/land/sky2@2x.jpg
  images/land/sea3@2x.jpg
+ images/land/beach4@2x.jpg
+ images/land/canyon9@2x.jpg
 Copyright: Emily Mell <hasmidas@gmail.com>
 License: public domain
 


### PR DESCRIPTION
I forgot to update the copyright file for my new changes to the planet images on Norn and Muspel. As always, I assign them to the public domain. Regular version change can be found here: https://github.com/endless-sky/endless-sky/pull/4060