### PR TITLE
Clean up unwanted trailing spaces

### DIFF
--- a/copyright
+++ b/copyright
@@ -1,4 +1,4 @@
-﻿Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: endless-sky-high-dpi
 Upstream-Contact: Michael Zahniser <mzahniser@gmail.com>
 Source: https://github.com/endless-sky/endless-sky-high-dpi
@@ -269,12 +269,12 @@ License: CC-BY-SA-4.0
 Comment: Screenshots of environments created with assets purchased by Tymoteusz
  Kapuściński from the Unity Asset Store. Post-processing applied by Michael
  Zahniser to make the images look less artificial.
- 
+
 Files: images/outfit/scan?module*
 Copyright: Zachary Siple
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (from under the same license).
- 
+
 Files: images/outfit/tactical?scanner*
 Copyright: Zachary Siple
 License: CC-BY-SA-4.0
@@ -320,7 +320,7 @@ Copyright: Various
 License: public-domain
  Taken from unsplash.com, a collection of photographs that have been donated and
  placed in the public domain.
- 
+
 Files:
  images/outfit/quarg?skylance*
  images/hardpoint/quarg?skylance*
@@ -610,7 +610,7 @@ Copyright: Becca Tommaso (tommasobecca03@gmail.com)
 License: CC-BY-SA-4.0
 Comment: Derived from works by Frederick Goy IV (under the same license).
 
-Files: 
+Files:
  images/outfit/security?station*
  images/ship/peregrine/*
 Copyright: Becca Tommaso (tommasobecca03@gmail.com)
@@ -1034,7 +1034,7 @@ Files:
  images/star/b3*
  images/star/b5*
  images/star/b8*
- images/star/black-hole* 
+ images/star/black-hole*
  images/star/carbon*
  images/star/f-dwarf*
  images/star/f-giant*


### PR DESCRIPTION
Similar to the PR on the main repo, but only affects one file.

Also removes the BOM that was lurking in `copyright`.