### PR TITLE
GitHub Action Check ES Low DPI Assets

### DIFF
--- a/.github/workflows/es-assets.yml
+++ b/.github/workflows/es-assets.yml
@@ -1,0 +1,17 @@
+name: Check Endless Sky Low DPI Assets
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  search_es_assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Find Low DPI Images in ES master branch
+        run: ./scripts/find-low-dpi-images.sh

--- a/.github/workflows/es-assets.yml
+++ b/.github/workflows/es-assets.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
     branches:
       - master
   # Allows you to run this workflow manually from the Actions tab

--- a/scripts/find-low-dpi-images.sh
+++ b/scripts/find-low-dpi-images.sh
@@ -51,4 +51,4 @@ fi
 (
   cd "${hidpi_assets}"
   find images -type f | sed 's/@2x//' | tr '\n' '\0'
-) | xargs -0 -I{} -n1 -P$(nproc) -- /bin/bash -ec 'test -f "'"${es_repo}"'/{}" || ( echo "Missing endless-sky/{}"; false )'
+) | xargs -0 -I{} -n1 -P"$(nproc)" -- /bin/bash -ec 'test -f "'"${es_repo}"'/{}" || ( echo "Missing endless-sky/{}"; false )'

--- a/scripts/find-low-dpi-images.sh
+++ b/scripts/find-low-dpi-images.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 # Created by Sam Gleske (@samrocketman on GitHub)
-# MIT licensed
+# GPLv3 licensed
 # Sat Aug 27 13:35:25 EDT 2022
-# Pop!_OS 18.04 LTS
-# Linux 5.4.0-113-generic x86_64
-# GNU bash, version 4.4.20(1)-release (x86_64-pc-linux-gnu)
-# find (GNU findutils) 4.7.0-git
-# xargs (GNU findutils) 4.7.0-git
-# git version 2.17.1
 #
 # DESCRIPTION
 #     Find images which exist in endless-sky-high-dpi but are missing from
@@ -16,9 +10,13 @@
 #     This script will exit non-zero if missing images are found.
 #
 # USAGE
-#     git clone https://github.com/endless-sky/endless-sky-high-dpi
-#     cd endless-sky-high-dpi/
-#     ../find-low-dpi-images.sh
+#     Stand alone
+#         git clone https://github.com/endless-sky/endless-sky-high-dpi
+#         cd endless-sky-high-dpi/
+#         ./scripts/find-low-dpi-images.sh
+#
+#     Using an already cloned repository.
+#         ./scripts/find-low-dpi-images.sh ~/git/endless-sky/
 
 set -exo pipefail
 
@@ -26,12 +24,31 @@ trap '[ ! -d "${TMP_DIR:-}" ] || rm -rf "${TMP_DIR}"' EXIT
 TMP_DIR="$(mktemp -d)"
 export TMP_DIR
 
+function canonicalize() (
+  cd "$1"
+  echo "$PWD"
+)
 
-pushd "${TMP_DIR}" &> /dev/null
-git clone --depth=1 https://github.com/endless-sky/endless-sky.git
+export hidpi_assets es_repo
+hidpi_assets="${PWD}"
+if [ -n "${1:-}" ] && [ -d "${1%/}/.git" ]; then
+  es_repo="$(canonicalize "${1}")"
+fi
+
+if [ -z "${es_repo:-}" ]; then
+  pushd "${TMP_DIR}" &> /dev/null
+  git clone --depth=1 https://github.com/endless-sky/endless-sky.git
+  es_repo="$(canonicalize "./endless-sky")"
+  popd &> /dev/null
+fi
+
+if [ "${hidpi_assets}" = "${es_repo}" ]; then
+  echo 'High DPI repo cannot test against itself.' >&2
+  exit 1
+fi
 
 # the following will exit non-zero if image not found
 (
-cd ~1/
-find images -type f | sed 's/@2x//' | tr '\n' '\0'
-) | xargs -0 -I{} -n1 -P$(nproc) -- /bin/bash -ec 'if [ -f "endless-sky/{}" ]; then exit;fi; echo "Missing endless-sky/{}"; false'
+  cd "${hidpi_assets}"
+  find images -type f | sed 's/@2x//' | tr '\n' '\0'
+) | xargs -0 -I{} -n1 -P$(nproc) -- /bin/bash -ec 'test -f "'"${es_repo}"'/{}" || ( echo "Missing endless-sky/{}"; false )'

--- a/scripts/find-low-dpi-images.sh
+++ b/scripts/find-low-dpi-images.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Created by Sam Gleske (@samrocketman on GitHub)
+# MIT licensed
+# Sat Aug 27 13:35:25 EDT 2022
+# Pop!_OS 18.04 LTS
+# Linux 5.4.0-113-generic x86_64
+# GNU bash, version 4.4.20(1)-release (x86_64-pc-linux-gnu)
+# find (GNU findutils) 4.7.0-git
+# xargs (GNU findutils) 4.7.0-git
+# git version 2.17.1
+#
+# DESCRIPTION
+#     Find images which exist in endless-sky-high-dpi but are missing from
+#     endless-sky repository.
+#
+#     This script will exit non-zero if missing images are found.
+#
+# USAGE
+#     git clone https://github.com/endless-sky/endless-sky-high-dpi
+#     cd endless-sky-high-dpi/
+#     ../find-low-dpi-images.sh
+
+set -exo pipefail
+
+trap '[ ! -d "${TMP_DIR:-}" ] || rm -rf "${TMP_DIR}"' EXIT
+TMP_DIR="$(mktemp -d)"
+export TMP_DIR
+
+
+pushd "${TMP_DIR}" &> /dev/null
+git clone --depth=1 https://github.com/endless-sky/endless-sky.git
+
+# the following will exit non-zero if image not found
+(
+cd ~1/
+find images -type f | sed 's/@2x//' | tr '\n' '\0'
+) | xargs -0 -I{} -n1 -P$(nproc) -- /bin/bash -ec 'if [ -f "endless-sky/{}" ]; then exit;fi; echo "Missing endless-sky/{}"; false'


### PR DESCRIPTION
This automated action will clone endless-sky master branch and verify that non-`@2x` versions of files exist.  It will exit with an error if the low DPI image equivalent is not already in upstream endless-sky master.

# Please note

All pull requests which are new will fail because they won't have assets in upstream master branch, yet.  However, once the upstream pull requests get merged you can manually re-run actions which should cause them to pass.

# Tested

You can see an example run https://github.com/samrocketman/endless-sky-high-dpi/runs/8166708770?check_suite_focus=true