### PR TITLE
fix(content): Remnant: Modified Dromedary names in the copyright

### DIFF
--- a/copyright
+++ b/copyright
@@ -1538,17 +1538,16 @@ License: CC0 (Creative Commons Zero)/Public-Domain
 Comment: Derived from works by MZ (under the same license), and contributions by Zoura, Kitteh, Ejo Thims, and Saugia
 
 Files:
- images/ship/dromedary*
- images/ship/dromedarywreck*
- images/thumbnail/dromedary*
- images/thumbnail/dromedarywreck*
+ images/ship/modified?dromedary*
+ images/ship/modified?dromedary?wreck*
+ images/thumbnail/modified?dromedary*
+ images/thumbnail/modified?dromedary?wreck*
 Copyright: Saugia (https://github.com/Saugia)
 License: CC-BY-SA-4.0
 
 Files:
- images/ship/dromedaryghost*
- images/ship/dromedaryspectre*
- images/thumb/dromedaryghost*
+ images/ship/modified?dromedary?ghost*
+ images/ship/modified?dromedary?spectre*
 Copyright: Saugia (https://github.com/Saugia)
 License: CC-BY-SA-4.0
 Comment: Transparent materials by scrinarii1337.


### PR DESCRIPTION
This adds spaces to the the names of the various modified dromedary ships; and removes reference to one thumbnail that does not exist.

Thanks to @leklachu for reporting it on the main PR #255 