### PR TITLE
fix easy problems with copyright/license summary

### DIFF
--- a/copyright
+++ b/copyright
@@ -90,7 +90,7 @@ Files:
  images/land/beach4*
  images/land/canyon9*
 Copyright: Emily Mell <hasmidas@gmail.com>
-License: public domain
+License: public-domain
 Based on public domain images taken from unsplash.com
 
 Files:

--- a/copyright
+++ b/copyright
@@ -1581,7 +1581,7 @@ Files:
 Copyright: Saugia <https://github.com/Saugia>
 Comment: Derived from works by NomadicVolcano (public domain).
 License: CC-BY-SA-4.0
- 
+
 Files:
  images/scene/ssil?vida?alert?hologram*
  images/scene/remnant?remote?spaceport*

--- a/copyright
+++ b/copyright
@@ -958,7 +958,6 @@ Files:
  images/planet/dyson1*
  images/planet/dyson2*
  images/planet/dyson3*
- images/planet/sheragi_postverta*
  images/planet/station0*
  images/planet/station1b*
  images/planet/station2b*

--- a/copyright
+++ b/copyright
@@ -1462,7 +1462,7 @@ Files:
  images/outfit/emp?torpedo?ii?bay*
  images/outfit/emp?torpedo?ii?pod*
  images/planet/gas3-c*
- images/ship/aerie* 
+ images/ship/aerie*
  images/ship/arch-carrack*
  images/ship/bactrian*
  images/ship/charm-shallop*

--- a/copyright
+++ b/copyright
@@ -687,13 +687,13 @@ Comment:
 Files:
  images/land/station8*
 Copyright: MTA of the State of New York
-License: CC BY 2.0
+License: CC-BY-2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/5836687124 and cropped.
 
 Files:
  images/land/station27*
 Copyright: Sebastian Sinisterra
-License: CC BY 2.0
+License: CC-BY-2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/17755765778 and cropped.
 
 Files:

--- a/copyright
+++ b/copyright
@@ -91,7 +91,7 @@ Files:
  images/land/canyon9*
 Copyright: Emily Mell <hasmidas@gmail.com>
 License: public-domain
-Based on public domain images taken from unsplash.com
+Comment: Based on public domain images taken from unsplash.com
 
 Files:
  images/icon/gat*
@@ -176,12 +176,14 @@ Files:
  images/planet/venus*
 Copyright: NASA
 License: public-domain
+Comment:
  From NASA, and therefore in the public domain because they were created by
  government employees while doing work for the government.
 
 Files: images/scene/*
 Copyright: Various
 License: public-domain
+Comment:
  Taken from morguefile.com, a collection of photographs that have been donated
  and placed in the public domain. (Exceptions noted below.)
 
@@ -198,6 +200,7 @@ License: public-domain
 Files: images/scene/army*
 Copyright: US Army
 License: public-domain
+Comment:
  From the US Army. Public domain because they are photographs taken by a
  government employee as part of their job.
 
@@ -210,12 +213,14 @@ Files:
  images/scene/engine2*
 Copyright: NASA
 License: public-domain
+Comment:
  From NASA, and therefore in the public domain because they were created by
  government employees while doing work for the government.
 
 Files: images/land/*
 Copyright: Various
 License: public-domain
+Comment:
  Taken from morgue-file.com, a collection of photographs that have been donated
  and placed in the public domain. (Exceptions noted below.)
 
@@ -325,6 +330,7 @@ Comment: Derived from works by Iaz Poolar (under the same license).
 Files: images/portrait/*
 Copyright: Various
 License: public-domain
+Comment:
  Taken from unsplash.com, a collection of photographs that have been donated and
  placed in the public domain.
 
@@ -652,6 +658,7 @@ Files:
  images/land/water13*
 Copyright: Various
 License: public-domain
+Comment:
  Taken from unsplash.com, a collection of photographs that have been donated and
  placed in the public domain.
 
@@ -659,6 +666,7 @@ Files:
  images/land/lava0*
 Copyright: USGS
 License: public-domain
+Comment:
  From the USGS, and therefore in the public domain because they were created by
  government employees while doing work for the government.
 
@@ -672,6 +680,7 @@ Files:
  images/land/station3*
 Copyright: NASA
 License: public-domain
+Comment:
  From NASA, and therefore in the public domain because they were created by
  government employees while doing work for the government.
 

--- a/copyright
+++ b/copyright
@@ -1644,8 +1644,9 @@ Files:
 Copyright: Anarchist2
 License: CC-BY-SA-4.0
 
-Files: images/thumbnail/smew
-Files: images/ship/smew
+Files:
+ images/thumbnail/smew
+ images/ship/smew
 Copyright: Dschiltt
 License: CC0 (Creative Commons Zero)/Public-Domain
 Comment: Derived from works by MZ (under the same license), and contributions by Zoura, Kitteh, Ejo Thims, and Saugia

--- a/copyright
+++ b/copyright
@@ -38,7 +38,7 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Christian Rhodes (under the same license).
 
 Files:
- images/ship/pointedstick_vanguard*
+ images/ship/pointedstick?vanguard*
 Copyright: Maximilian Korber
 License: CC-BY-SA-4.0
 Comment: Derived from works by Nate Graham (under the same license).
@@ -56,7 +56,7 @@ Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
  images/projectile/bullet*
- images/outfit/bullet?impact*
+ images/effect/bullet?impact*
 Copyright: Iaz Poolar
 License: CC-BY-SA-4.0
 Comment: Derived from works by Amazinite derived from works by Michael Zahniser (under the same license).
@@ -531,7 +531,7 @@ Files:
  images/land/desert2*
  images/land/desert11*
  images/land/desert12*
- images/land/deser13*
+ images/land/desert13*
  images/land/dune1*
  images/land/fields1*
  images/land/fields2*
@@ -709,7 +709,7 @@ License: CC0
 Comment: Taken from https://pxhere.com/en/photo/119196 and cropped.
 
 Files:
- images/land/station5.jpg
+ images/land/station5*
 Copyright: Damien Jemison
 License: CC-BY-SA-3.0
 Comment: Taken from https://commons.wikimedia.org/wiki/File:Preamplifier_at_the_National_Ignition_Facility.jpg
@@ -720,9 +720,9 @@ Copyright: Michael Zahniser <mzahniser@gmail.com>
 License: CC-BY-SA-4.0
 
 Files:
- images/outfit/T3?anti?missile*
+ images/outfit/t3?anti?missile*
  images/outfit/pug?gridfire?turret*
- images/hardpoint/T3?anti?missile*
+ images/hardpoint/t3?anti?missile*
  images/hardpoint/pug?gridfire?turret*
 Copyright: Becca Tommaso (tommasobecca03@gmail.com)
 License: CC-BY-SA-4.0
@@ -1450,7 +1450,7 @@ Files:
  images/outfit/firestorm?rack*
  images/outfit/firestorm?torpedo*
  images/projectile/firestorm?torpedo*
- images/outfit/mcs?exctractor*
+ images/outfit/mcs?extractor*
  images/ship/modified?dromedary*
  images/ship/modified?dromedary?wreck*
  images/thumbnail/modified?dromedary*
@@ -1478,7 +1478,7 @@ Files:
  images/thumbnail/arch-carrack*
  images/thumbnail/bactrian*
  images/thumbnail/charm-shallop*
- images/ship/echo-galleon*
+ images/thumbnail/echo-galleon*
  images/thumbnail/hailstone*
  images/thumbnail/heavy?gust*
  images/thumbnail/mining?drone*
@@ -1517,7 +1517,7 @@ Files:
  images/planet/station7cb*
  images/projectile/firelight*
  images/projectile/firelight?active*
- images/projectiles/ionic?blast*
+ images/projectile/ionic?blast*
 Copyright: Saugia <https://github.com/Saugia>
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and Becca Tommaso (under the same license).
@@ -1556,7 +1556,7 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and Lia Gerty (under the same license).
 
 Files:
- images/hardpoint/microbot?factory*
+ images/hardpoint/factory/microbot?factory*
  images/ship/-nra-ret*
  images/ship/ikatila-ej*
  images/ship/modified?ladybug*
@@ -1626,7 +1626,7 @@ Files:
 Copyright: Scrinarii1337#0001
 License: CC-BY-SA-4.0
 
-Files: images/land/asteroid0
+Files: images/land/asteroid0*
 Copyright: Becca Tommaso
 License: CC0 (Creative Commons Zero)/Public-Domain
 Comment: Derived from works by ESA/Rosetta spacecraft (under the same license).
@@ -1645,8 +1645,8 @@ Copyright: Anarchist2
 License: CC-BY-SA-4.0
 
 Files:
- images/thumbnail/smew
- images/ship/smew
+ images/thumbnail/smew*
+ images/ship/smew*
 Copyright: Dschiltt
 License: CC0 (Creative Commons Zero)/Public-Domain
 Comment: Derived from works by MZ (under the same license), and contributions by Zoura, Kitteh, Ejo Thims, and Saugia
@@ -1661,7 +1661,7 @@ License: CC-BY-SA-4.0
 
 Files:
  images/ship/modified?dromedary?ghost*
- images/ship/modified?dromedary?spectre*
+ images/ship/modified?dromedary?specter*
 Copyright: Saugia (https://github.com/Saugia)
 License: CC-BY-SA-4.0
 Comment: Transparent materials by scrinarii1337.

--- a/copyright
+++ b/copyright
@@ -1674,7 +1674,7 @@ Copyright: Daeridanii (https://github.com/Daeridanii1)
 License: CC-BY-SA-4.0
 Comment: Derived from works by Becca Tommaso and Michael Zahniser (under the same license).
 
-Files
+Files:
  images/ship/hai?ladybug*
  images/thumbnail/hai?ladybug*
  images/planet/station?hai?eight?geocoris*
@@ -1682,13 +1682,13 @@ Copyright: None (CC0: Public Domain)
 License: CC0: Public Domain
 Comment: Made by Nomadic Volcano with textures from texture.ninja.
 
-Files
+Files:
  images/planet/wormhole-syndicate-ad*
 Copyright: NomadicVolcano (NomadicVolcano@gmail.com)
 License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license)
 
-Files
+Files:
  images/planet/station?hai?geocoris*
 Copyright: Nomadic Volcano (NomadicVolcano@gmail.com)
 License: CC-BY-SA-4.0

--- a/copyright
+++ b/copyright
@@ -10,7 +10,7 @@ License: CC-BY-SA-4.0
 Files:
  images/outfit/*battery?hai*
  images/outfit/anti-missile?hai*
- images/outfit/cooling ducts?hai*
+ images/outfit/cooling?ducts?hai*
  images/outfit/dwarf?core?hai*
  images/outfit/fission?hai*
  images/outfit/fusion?hai*
@@ -77,7 +77,7 @@ License: CC-BY-SA-4.0
 
 Files:
  images/ship/vanguard*
- images/outfit/luxury accommodations*
+ images/outfit/luxury?accommodations*
  images/outfit/proton?turret*
  images/hardpoint/proton?turret*
  images/outfit/brig*
@@ -763,7 +763,7 @@ Files:
  images/ship/hauler?i*
  images/ship/hauler?ii*
  images/ship/hauler?iii*
- images/ship/modified argosy*
+ images/ship/modified?argosy*
  images/ship/bastion*
  images/ship/behemoth*
  images/ship/heavy?shuttle*
@@ -785,7 +785,7 @@ Files:
  images/thumbnail/hauler?i*
  images/thumbnail/hauler?ii*
  images/thumbnail/hauler?iii*
- images/thumbnail/modified argosy*
+ images/thumbnail/modified?argosy*
  images/thumbnail/bastion*
  images/thumbnail/behemoth*
  images/thumbnail/heavy?shuttle*
@@ -815,7 +815,7 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license) and detailed by Becca Tommaso (tommasobecca03@gmail.com).
 
 Files:
- images/ship/pointedstick vanguard*
+ images/ship/pointedstick?vanguard*
 Copyright: Maximilian Korber
 License: CC-BY-SA-4.0
 Comment: Derived from works by Nate Graham (under the same license) and detailed by Becca Tommaso (tommasobecca03@gmail.com).
@@ -1393,7 +1393,7 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
- images/projectile/korath inferno*
+ images/projectile/korath?inferno*
 Copyright: Gefüllte Taubenbrust <jeaminer23@gmail.com>
 License: CC-BY-SA-4.0
 Comment: Derived from works by Nomadic Volcano (under the same license).
@@ -1445,7 +1445,7 @@ License: CC-BY-SA-4.0
 Comment: Derived from works by Michael Zahniser (under the same license).
 
 Files:
- images/hardpoint/firestorm battery*
+ images/hardpoint/firestorm?battery*
  images/outfit/firestorm?battery*
  images/outfit/firestorm?rack*
  images/outfit/firestorm?torpedo*

--- a/copyright
+++ b/copyright
@@ -678,13 +678,13 @@ License: public-domain
 Files:
  images/land/station8*
 Copyright: MTA of the State of New York
-Licence: CC BY 2.0
+License: CC BY 2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/5836687124 and cropped.
 
 Files:
  images/land/station27*
 Copyright: Sebastian Sinisterra
-Licence: CC BY 2.0
+License: CC BY 2.0
 Comment: Taken from https://www.flickr.com/photos/61135621@N03/17755765778 and cropped.
 
 Files:
@@ -1544,7 +1544,7 @@ Files:
  images/thumbnail/tubfalet*
 Copyright: Saugia <https://github.com/Saugia>
 License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license) and Lia Gerty (under the same licence).
+Comment: Derived from works by Michael Zahniser (under the same license) and Lia Gerty (under the same license).
 
 Files:
  images/hardpoint/microbot?factory*
@@ -1564,7 +1564,7 @@ Comment: Derived from works by NomadicVolcano (public domain).
 Files:
  images/outfit/microbot?defense?station*
 Copyright: Saugia <https://github.com/Saugia>
-Comment: Derived from work by Griffin Schutte (theronepic@gmail.com) (under same licence).
+Comment: Derived from work by Griffin Schutte (theronepic@gmail.com) (under same license).
 License: CC-BY-SA-4.0
 
 Files:

--- a/copyright
+++ b/copyright
@@ -78,8 +78,8 @@ License: CC-BY-SA-4.0
 Files:
  images/ship/vanguard*
  images/outfit/luxury accommodations*
- images/outfit/proton turret*
- images/hardpoint/proton turret*
+ images/outfit/proton?turret*
+ images/hardpoint/proton?turret*
  images/outfit/brig*
 Copyright: Nate Graham <pointedstick@zoho.com>
 License: CC-BY-SA-4.0


### PR DESCRIPTION
These are the easy ones - bad syntax, obvious typos etc.

A separate issue is due for the hard ones like overlapping entries, entries that match no files and copyrighted files licensed as 'public domain'