### PR TITLE
Add workflow to test parse this plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - releases/v[0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-parse:
+    name: Data Files
+    runs-on: windows-2022
+    env:
+      CONTINUOUS: EndlessSky-win64-continuous.zip
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: 'endless-sky/endless-sky'
+    - name: Download latest continuous
+      run: gh release download -R endless-sky/endless-sky continuous -p ${{ env.CONTINUOUS }}
+    - name: Extract and prepare continuous
+      run: |
+        Expand-Archive ${{ env.CONTINUOUS }} -DestinationPath continuous -Force
+        COPY '.\continuous\Endless Sky.exe' .
+        COPY '.\continuous\*.dll' .
+        mkdir plugins
+        cd .\plugins
+        mkdir endless-sky-high-dpi
+    - uses: actions/checkout@v4
+      with:
+        path: '.\plugins\endless-sky-high-dpi'
+    - name: Parse Datafiles
+      run: .\utils\test_parse.ps1 'Endless Sky.exe'


### PR DESCRIPTION
Copy-pasted from the data files check in endless-sky/endless-sky, with some edits as appropriate.
Running on the PR now just to test that it runs, but we won't be able to run it on other PRs as it is because those will have @2x versions of images that do not exist in the base game, (that's generally the point of PRs here) and I can't tell it to check out the branch for the relevant PR to endless-sky/endless-sky.