### PR TITLE
Update copyright for tactical scan icons

### DIFF
--- a/copyright
+++ b/copyright
@@ -3169,15 +3169,6 @@ Copyright: Zitchas (zitchas.jma@gmail.com)
 License: CC-BY-SA-4.0
 
 Files:
- images/ui/tactical/crew*
- images/ui/tactical/energy*
- images/ui/tactical/fuel*
- images/ui/tactical/thermal*
-Copyright: Zitchas
-License: CC-BY-SA-4.0
-Comment: Derived from works by Michael Zahniser (under the same license).
-
-Files:
  images/ui/sales?key*
 Copyright: Dave Flowers
 License: CC-BY-SA-4.0


### PR DESCRIPTION
https://github.com/endless-sky/endless-sky/pull/10921

Removes what I believe is an inaccurate copyright entry:

> The image at https://github.com/endless-sky/endless-sky/blob/12bd2b14526809a257cf66f46750f97126aa7011/images/ui/tactical/tactical.png was previously used for the tactical scan display.
It is composed of four separate, disconnected icons all in one file.
In https://github.com/endless-sky/endless-sky/pull/8172, it those four icons were moved into their own files:
https://github.com/endless-sky/endless-sky/blob/12bd2b14526809a257cf66f46750f97126aa7011/images/ui/tactical/crew.png
https://github.com/endless-sky/endless-sky/blob/12bd2b14526809a257cf66f46750f97126aa7011/images/ui/tactical/fuel.png
https://github.com/endless-sky/endless-sky/blob/12bd2b14526809a257cf66f46750f97126aa7011/images/ui/tactical/energy.png
https://github.com/endless-sky/endless-sky/blob/12bd2b14526809a257cf66f46750f97126aa7011/images/ui/tactical/thermal.png
These images are identical to the ones in the original file, they are simply on their own canvases.
It is, at best, cropping, but since the images are actually unchanged, even that is, I think, too far.
> 
> I do not believe taking images from one file and moving them to another is sufficient for a person to claim copyright over them. And describing them as "derived from" the original file is reductive, and possibly misleading, as it suggests that the images have been changed when they have not.
> 
> This PR removed the copyright entry that was added for these four new files in https://github.com/endless-sky/endless-sky/pull/8172, resulting in those files receiving the same copyright attribution that the original "tactical.png" file did.
