### PR TITLE
Update tactical icon copyrights again

### DIFF
--- a/copyright
+++ b/copyright
@@ -3174,7 +3174,7 @@ Files:
  images/ui/tactical/energy*
  images/ui/tactical/fuel*
  images/ui/tactical/thermal*
-Copyright: Michael Zahniser
+Copyright: Michael Zahniser <mzahniser@gmail.com>
 License: CC-BY-SA-4.0
 Comment: Cropped and split into four new files by Zitchas (zitchas.jma@gmail.com)
 

--- a/copyright
+++ b/copyright
@@ -3176,7 +3176,7 @@ Files:
  images/ui/tactical/thermal*
 Copyright: Michael Zahniser
 License: CC-BY-SA-4.0
-Comment: Zitchas (zitchas.jma@gmail.com)
+Comment: Cropped and split into four new files by Zitchas (zitchas.jma@gmail.com)
 
 Files:
  images/ui/sales?key*

--- a/copyright
+++ b/copyright
@@ -3170,6 +3170,15 @@ Copyright: Zitchas (zitchas.jma@gmail.com)
 License: CC-BY-SA-4.0
 
 Files:
+ images/ui/tactical/crew*
+ images/ui/tactical/energy*
+ images/ui/tactical/fuel*
+ images/ui/tactical/thermal*
+Copyright: Michael Zahniser
+License: CC-BY-SA-4.0
+Comment: Zitchas (zitchas.jma@gmail.com)
+
+Files:
  images/ui/sales?key*
 Copyright: Dave Flowers
 License: CC-BY-SA-4.0


### PR DESCRIPTION
Following on from https://github.com/endless-sky/endless-sky/pull/10921, this PR modifies the copyright entry for those icons to include a description stating that they were cropped by Zitchas, while still indicating that the copyright owner is Michael Zahniser.
I'm not going to copy-paste the description and conversation on that PR here.

Linked to https://github.com/endless-sky/endless-sky/pull/10932